### PR TITLE
Implement TCP client and add minimal example which uses it.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,3 +21,4 @@ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 # add subfolders
 # --------------
 add_subdirectory(c24)
+add_subdirectory(examples)

--- a/c24/communication/CMakeLists.txt
+++ b/c24/communication/CMakeLists.txt
@@ -2,11 +2,25 @@ project(communication)
 
 set(${PROJECT_NAME}_headers
   stream_backend_interface.h
+  stream_tcp.h
+  stream_tcp_client.h
   stream.h)
 set(${PROJECT_NAME}_sources
+  stream_tcp.cpp
+  stream_tcp_client.cpp
   stream.cpp)
 
 add_library(${PROJECT_NAME} STATIC ${${PROJECT_NAME}_headers} ${${PROJECT_NAME}_sources})
 
 include_directories(${CMAKE_SOURCE_DIR}/c24/extern/google-glog-master/src/)
 target_link_libraries(${PROJECT_NAME} google-glog)
+
+# Detect and add SFML
+set(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake_modules" ${CMAKE_MODULE_PATH})
+#Find any version 2.X of SFML
+#See the FindSFML.cmake file for additional details and instructions
+find_package(SFML 2 REQUIRED system window graphics network audio)
+if(SFML_FOUND)
+  include_directories(${SFML_INCLUDE_DIR})
+  target_link_libraries(${PROJECT_NAME} ${SFML_LIBRARIES})
+endif()

--- a/c24/communication/stream_tcp.cpp
+++ b/c24/communication/stream_tcp.cpp
@@ -1,0 +1,92 @@
+#include "c24/communication/stream_tcp.h"
+
+#include <glog/logging.h>
+
+namespace c24 {
+namespace communication {
+
+bool StreamTcp::MessageAvailable() {
+  // Check if there is some message in the queue already.
+  if (!complete_messages_.empty()) {
+    return true;
+  }
+  if (socket_.isBlocking()) {
+    socket_.setBlocking(false);
+  }
+  std::size_t received;
+  sf::TcpSocket::Status status = GetData(&received);
+  if (status == sf::TcpSocket::Error || status == sf::TcpSocket::Disconnected) {
+    LOG(ERROR) << "TcpSocket error. Status code: " << status;
+  }
+  // if status == sf::TcpSocket::NotReady no message is yet available.
+  return status == sf::TcpSocket::Done;
+}
+
+std::string StreamTcp::GetMessage() {
+  if (complete_messages_.empty()) {
+    if (!socket_.isBlocking()) {
+      socket_.setBlocking(true);
+    }
+    // More than one read may be necessary if the message is longer than
+    // _TCP_BUFFER_SIZE.
+    while (complete_messages_.empty()) {
+      std::size_t received;
+      sf::TcpSocket::Status status = GetData(&received);
+      if (status == sf::TcpSocket::NotReady || status == sf::TcpSocket::Error ||
+          status == sf::TcpSocket::Disconnected) {
+        LOG(ERROR)
+            << "TcpSocket error when trying to receive data. Status code: "
+            << status;
+        continue;
+      }
+      if (received == 0) {
+        LOG(ERROR) << "Trying to read in blocking mode but no data received";
+      }
+    }
+  }
+  std::string msg = complete_messages_.front();
+  complete_messages_.pop();
+  return msg;
+}
+
+bool StreamTcp::SendMessage(const std::string& msg) {
+  // Set the socket to blocking mode to guarantee the whole message is sent.
+  if (!socket_.isBlocking()) {
+    socket_.setBlocking(true);
+  }
+  sf::TcpSocket::Status status = socket_.send(msg.c_str(), msg.length());
+  if (status != sf::TcpSocket::Done) {
+    if (status == sf::TcpSocket::Disconnected) {
+      connected_ = false;
+    }
+    LOG(ERROR) << "TcpSocket error. Status code: " << status;
+  }
+  return status == sf::TcpSocket::Done;
+}
+
+// Internally the class remembers queue of received messages. Every time some
+// data is received it is stored in buffer_[] and the received data is
+// processed. When newline character is found, message is saved to queue
+// complete_messages_. Last not complete message (not yet terminated by newline)
+// is saved in not_complete_message_.
+sf::TcpSocket::Status StreamTcp::GetData(std::size_t* received) {
+  sf::TcpSocket::Status status =
+      socket_.receive(buffer_, _TCP_BUFFER_SIZE, *received);
+  if (status == sf::TcpSocket::Disconnected) {
+    connected_ = false;
+  }
+  if (status == sf::TcpSocket::Done) {
+    for (std::size_t i = 0; i < *received; ++i) {
+      if (buffer_[i] == '\n') {
+        complete_messages_.push(not_complete_message_);
+        not_complete_message_ = "";
+      } else {
+        not_complete_message_.push_back(buffer_[i]);
+      }
+    }
+  }
+  return status;
+}
+
+}  // namespace communication
+}  // namespace c24

--- a/c24/communication/stream_tcp.h
+++ b/c24/communication/stream_tcp.h
@@ -1,0 +1,58 @@
+#ifndef COMMUNICATION_STREAM_TCP_H_
+#define COMMUNICATION_STREAM_TCP_H_
+
+#include <string>
+#include <queue>
+
+#include <SFML/Network.hpp>
+
+#include "c24/communication/stream_backend_interface.h"
+
+// Specifies the maximum number of characters received at once.
+#ifndef _TCP_BUFFER_SIZE
+#define _TCP_BUFFER_SIZE 100
+#endif  // _TCP_BUFFER_SIZE
+
+namespace c24 {
+namespace communication {
+
+// Implementation of StreamBackendInterface for tcp streams -- both client and
+// server. Constructor is protected so that the class is abstract.
+class StreamTcp : public StreamBackendInterface {
+ public:
+  virtual ~StreamTcp() {}
+
+  // Non-blocking call to check if there is a message available on the stream.
+  bool MessageAvailable() override;
+
+  // Blocking call that receives one line. Returned string does not contain the
+  // newline character.
+  std::string GetMessage() override;
+
+  // Blocking call that sends a message (without newline). Returns true on
+  // success.
+  bool SendMessage(const std::string& msg) override;
+
+  // Returns if the connection is still valid.
+  bool Connected() const override { return connected_; }
+ protected:
+  StreamTcp() {}
+
+  sf::TcpSocket socket_;
+  bool connected_;
+ private:
+  // Get raw data from the socket and if successful, process it.
+  sf::TcpSocket::Status GetData(std::size_t* received);
+
+  // For storing received raw data.
+  char buffer_[_TCP_BUFFER_SIZE + 1];
+  // Part of the last message -- not yet terminated by newline character.
+  std::string not_complete_message_;
+  // Queue of all received messages not yet obtained by GetMessage method.
+  std::queue<std::string> complete_messages_;
+};
+
+}  // namespace communication
+}  // namespace c24
+
+#endif //  COMMUNICATION_STREAM_TCP_H_

--- a/c24/communication/stream_tcp_client.cpp
+++ b/c24/communication/stream_tcp_client.cpp
@@ -1,0 +1,21 @@
+#include "c24/communication/stream_tcp_client.h"
+
+#include <glog/logging.h>
+
+namespace c24 {
+namespace communication {
+
+StreamTcpClient::StreamTcpClient(const sf::IpAddress& ip_address,
+                                 unsigned short port) {
+  sf::Socket::Status status = socket_.connect(ip_address, port);
+  if (status == sf::Socket::Done) {
+    connected_ = true;
+  } else {
+    connected_ = false;
+    LOG(ERROR) << "Unable to connect to host. IP address: " << ip_address
+               << ", port: " << port;
+  }
+}
+
+}  // namespace communication
+}  // namespace c24

--- a/c24/communication/stream_tcp_client.h
+++ b/c24/communication/stream_tcp_client.h
@@ -1,0 +1,28 @@
+#ifndef COMMUNICATION_STREAM_TCP_CLIENT_H_
+#define COMMUNICATION_STREAM_TCP_CLIENT_H_
+
+#include <string>
+#include <queue>
+
+#include <SFML/Network.hpp>
+
+#include "c24/communication/stream_tcp.h"
+
+namespace c24 {
+namespace communication {
+
+// Implementation of StreamBackendInterface for tcp client.
+class StreamTcpClient : public StreamTcp {
+ public:
+  // Connect to server at specified location.
+  StreamTcpClient(const sf::IpAddress& ip_address, unsigned short port);
+  StreamTcpClient(const std::string& ip_address, unsigned short port)
+      : StreamTcpClient(sf::IpAddress(ip_address), port) {}
+  StreamTcpClient(const char* ip_address, unsigned short port)
+      : StreamTcpClient(sf::IpAddress(ip_address), port) {}
+};
+
+}  // namespace communication
+}  // namespace c24
+
+#endif //  COMMUNICATION_STREAM_TCP_CLIENT_H_

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,0 +1,15 @@
+# Examples.
+project(examples)
+
+# tcp_client
+set(tcp_client ${PROJECT_NAME}_tcp_client)
+set(${tcp_client}_sources tcp_client.cpp)
+
+add_executable(${tcp_client} ${${tcp_client}_sources})
+target_link_libraries(${tcp_client} communication)
+
+include_directories(${CMAKE_SOURCE_DIR}/c24/extern/gfags-master/src/)
+target_link_libraries(${tcp_client} gflags)
+
+include_directories(${CMAKE_SOURCE_DIR}/c24/extern/google-glog-master/src/)
+target_link_libraries(${tcp_client} google-glog)

--- a/examples/tcp_client.cpp
+++ b/examples/tcp_client.cpp
@@ -1,0 +1,30 @@
+// This example shows how to use the TCP client. It connects to server, sends
+// one message and receives one message.
+
+#include <memory>
+
+#include <iostream>
+#include <glog/logging.h>
+#include <gflags/gflags.h>
+#include "c24/communication/stream.h"
+#include "c24/communication/stream_tcp_client.h"
+#include "c24/communication/stream_backend_interface.h"
+
+using c24::communication::StreamBackendInterface;
+using c24::communication::StreamTcpClient;
+using c24::communication::Stream;
+
+DEFINE_string(host, "127.0.0.1",
+              "Define hostname to which do you want to connect.");
+DEFINE_int32(port, 5500, "Define port number to which do you want to connect.");
+
+int main(int argc, char** argv) {
+  google::InitGoogleLogging(*argv);
+  google::ParseCommandLineFlags(&argc, &argv, true);
+  Stream stream = Stream(std::unique_ptr<StreamBackendInterface>(
+      new StreamTcpClient(FLAGS_host, FLAGS_port)));
+  stream.SendMessage("HELLO SERVER");
+  std::cout << stream.GetMessage() << std::endl;
+
+  return 0;
+}


### PR DESCRIPTION
Files <code>stream_tcp.h</code> and <code>stream_tcp.cpp</code> contain the code that will be reusable also for for TCP server. They define abstract class <code>StreamTcp</code> that implements methods of <code>StreamBackendInterface</code> and can be used as a base class for both TCP client and TCP server.
