### PR TITLE
Revert "Change in CMakeLists for glog library. Comment out NO_THREADS…

### DIFF
--- a/c24/extern/google-glog-master/CMakeLists.txt
+++ b/c24/extern/google-glog-master/CMakeLists.txt
@@ -112,7 +112,7 @@ else()
 		${GFLAGS_INCLUDE_DIRS}
 	)
 
-  # mz_add_definition(NO_THREADS)
+	mz_add_definition(NO_THREADS)
 	set(GLOG_3LIBS pthread)
         if( HAVE_LIB_UNWIND )
             set(GLOG_3LIBS ${GLOG_3LIBS} unwind)


### PR DESCRIPTION
Reverts simsa-st/contest24#14
The library does not build without it.
